### PR TITLE
Logging in extension debugger

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -63,6 +63,11 @@ var config = { //this is from https://developer.mozilla.org/en-US/docs/Setting_u
 		e: false,
 		d: true,
 		type: 'Bool'
+	},
+	'extensions.sdk.console.logLevel': {
+		e: 'all',
+		d: 'error',
+		type: 'Char'
 	}
 };
 

--- a/options.xul
+++ b/options.xul
@@ -15,4 +15,17 @@
 	<setting pref="devtools.hud.loglimit.security" title="Security :: Console Auto Discard Limit" type="integer">
 		After this many lines of messages in the "Security" category, the oldest ones will be automatically discarded. Default: Not Limited (No Preference Value)
 	</setting>
+	<setting pref="extensions.sdk.console.logLevel" title="Extensions :: Log level" type="menulist">
+		Enables your add-on to log error, warning or informational messages.
+		<menulist>
+				<menupopup>
+					<menuitem value="all" label="all"/>
+					<menuitem value="debug" label="debug: debug, error, exception, info, log, time, timeEnd, trace, warn"/>
+					<menuitem value="info" label="info: error, exception, info, log, time, timeEnd, trace, warn"/>
+					<menuitem value="warn" label="warn: error, exception, warn"/>
+					<menuitem value="error" label="error: error, exception"/>
+					<menuitem value="off" label="off"/>
+				</menupopup>
+			</menulist>
+	</setting>
 </vbox>


### PR DESCRIPTION
Hi. There is a special setting that enables full logging for an extension. It really helpful for development.

Setting: extensions.sdk.console.logLevel
Details: https://developer.mozilla.org/en-US/Add-ons/SDK/Tools/console

Please accept my pull request, that will help a lot.



